### PR TITLE
remove dependency to eband_local_planner

### DIFF
--- a/cob_navigation_global/package.xml
+++ b/cob_navigation_global/package.xml
@@ -20,7 +20,6 @@
   <exec_depend>cob_navigation_config</exec_depend>
   <exec_depend>cob_scan_unifier</exec_depend>
   <exec_depend>dwa_local_planner</exec_depend>
-  <exec_depend>eband_local_planner</exec_depend>
   <exec_depend>map_server</exec_depend>
   <exec_depend>move_base</exec_depend>
   <exec_depend>rviz</exec_depend>


### PR DESCRIPTION
The launch files have been removed in https://github.com/ipa320/cob_navigation/commit/015cec3b7c441ff8bd2d7bd97ffe985866ea14a1
But the dependency has been kept....