### PR TITLE
Code restructuring to provide map accessibility check as ROS service and C++ library

### DIFF
--- a/cob_map_accessibility_analysis/CMakeLists.txt
+++ b/cob_map_accessibility_analysis/CMakeLists.txt
@@ -1,14 +1,12 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(cob_map_accessibility_analysis)
 
-find_package(catkin REQUIRED COMPONENTS
-  #cob_3d_mapping_common
+set(catkin_RUN_PACKAGES
   cob_3d_mapping_msgs
   cv_bridge
   geometry_msgs
   image_transport
   message_filters
-  message_generation
   nav_msgs
   pcl_ros
   roscpp
@@ -16,8 +14,18 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
-find_package(OpenCV REQUIRED)
+set(catkin_BUILD_PACKAGES
+	${catkin_RUN_PACKAGES}
+	cmake_modules
+	message_generation
+)
+
+find_package(catkin REQUIRED COMPONENTS
+  ${catkin_BUILD_PACKAGES}
+)
+
 find_package(Boost REQUIRED)
+find_package(OpenCV REQUIRED)
 
 catkin_python_setup()
 
@@ -32,22 +40,46 @@ generate_messages(
     geometry_msgs
 )
 
-catkin_package()
+catkin_package(
+INCLUDE_DIRS
+	ros/include
+LIBRARIES
+	map_accessibility_analysis
+CATKIN_DEPENDS
+	${catkin_RUN_PACKAGES}
+	message_runtime
+DEPENDS
+	Boost
+	OpenCV
+)
 
 include_directories(
   ros/include
   ${catkin_INCLUDE_DIRS}
-  ${OpenCV_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
+  ${OpenCV_INCLUDE_DIRS}
 )
 
+# map_accessibility_analysis lib
+add_library(map_accessibility_analysis
+  ros/src/map_accessibility_analysis.cpp
+)
+target_link_libraries(map_accessibility_analysis
+  ${catkin_LIBRARIES}
+  ${Boost_LIBRARIES}
+  ${OpenCV_LIBRARIES}
+)
+add_dependencies(map_accessibility_analysis ${catkin_EXPORTED_TARGETS})
 
 # map_accessibility_analysis_server
-add_executable(map_accessibility_analysis_server ros/src/map_accessibility_analysis_server.cpp)
+add_executable(map_accessibility_analysis_server
+  ros/src/map_accessibility_analysis_server.cpp
+)
 target_link_libraries(map_accessibility_analysis_server
   ${catkin_LIBRARIES}
-  ${OpenCV_LIBRARIES}
   ${Boost_LIBRARIES}
+  ${OpenCV_LIBRARIES}
+  map_accessibility_analysis
 )
 add_dependencies(map_accessibility_analysis_server ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
@@ -56,8 +88,8 @@ add_dependencies(map_accessibility_analysis_server ${${PROJECT_NAME}_EXPORTED_TA
 add_executable(map_accessibility_analysis_client ros/src/map_accessibility_analysis_client.cpp)
 target_link_libraries(map_accessibility_analysis_client
   ${catkin_LIBRARIES}
-  ${OpenCV_LIBRARIES}
   ${Boost_LIBRARIES}
+  ${OpenCV_LIBRARIES}
 )
 add_dependencies(map_accessibility_analysis_client ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 

--- a/cob_map_accessibility_analysis/package.xml
+++ b/cob_map_accessibility_analysis/package.xml
@@ -17,7 +17,6 @@
   <exec_depend>message_runtime</exec_depend>
 
   <depend>boost</depend>
-  <!--depend>cob_3d_mapping_common</depend-->
   <depend>cob_3d_mapping_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>

--- a/cob_map_accessibility_analysis/package.xml
+++ b/cob_map_accessibility_analysis/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>message_runtime</exec_depend>
 
   <depend>boost</depend>
+  <depend>cmake_modules</depend>
   <depend>cob_3d_mapping_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>

--- a/cob_map_accessibility_analysis/ros/include/cob_map_accessibility_analysis/map_accessibility_analysis.h
+++ b/cob_map_accessibility_analysis/ros/include/cob_map_accessibility_analysis/map_accessibility_analysis.h
@@ -83,20 +83,6 @@ public:
 	void checkPerimeter(std::vector<Pose>& accessible_poses_on_perimeter,
 			const Pose& center, const double radius, const double rotational_sampling_step,
 			const cv::Mat& inflated_map, const bool approach_path_accessibility_check, const cv::Point& robot_location);
-protected:
-
-	/*
-	 * This function computes whether a given point (potentialApproachPose) is accessible by the robot at location robotLocation
-	 */
-	bool isApproachPositionAccessible(const cv::Point& robotLocation,
-			const cv::Point& potentialApproachPose,
-			std::vector<std::vector<cv::Point> > contours);
-
-	/*
-	 * pose_p and closest_point_on_polygon in pixel coordinates!
-	 */
-	void computeClosestPointOnPolygon(const cv::Mat& map_with_polygon,
-			const Pose& pose_p, Pose& closest_point_on_polygon);
 
 	template<class T>
 	T convertFromMeterToPixelCoordinates(const Pose& pose, const cv::Point2d& map_origin, const double inverse_map_resolution)
@@ -115,5 +101,21 @@ protected:
 		val.y = map_resolution * pose.y + map_origin.y;
 		return val;
 	}
+
+protected:
+
+	/*
+	 * This function computes whether a given point (potentialApproachPose) is accessible by the robot at location robotLocation
+	 */
+	bool isApproachPositionAccessible(const cv::Point& robotLocation,
+			const cv::Point& potentialApproachPose,
+			std::vector<std::vector<cv::Point> > contours);
+
+	/*
+	 * pose_p and closest_point_on_polygon in pixel coordinates!
+	 */
+	void computeClosestPointOnPolygon(const cv::Mat& map_with_polygon,
+			const Pose& pose_p, Pose& closest_point_on_polygon);
+
 };
 

--- a/cob_map_accessibility_analysis/ros/include/cob_map_accessibility_analysis/map_accessibility_analysis.h
+++ b/cob_map_accessibility_analysis/ros/include/cob_map_accessibility_analysis/map_accessibility_analysis.h
@@ -1,0 +1,119 @@
+/*
+* Copyright (c) 2016-2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <vector>
+
+#include <opencv2/opencv.hpp>
+
+class MapAccessibilityAnalysis
+{
+public:
+
+	struct Pose
+	{
+		float x;
+		float y;
+		float orientation;  // in degree
+
+		Pose()
+		{
+			x = 0;
+			y = 0;
+			orientation = 0;
+		}
+
+		Pose(float x_, float y_, float orientation_)
+		{
+			x = x_;
+			y = y_;
+			orientation = orientation_;
+		}
+	};
+
+
+	MapAccessibilityAnalysis();
+	~MapAccessibilityAnalysis();
+
+	/**
+	 * Inflates the walls and obstacles in a map by the radius of the robot, resulting in a map of accessible areas for the robot.
+	 *
+	 * \param robot_radius_pixel Provides the robot radius converted to pixels in the given maps, in [px]
+	 */
+	void inflateMap(const cv::Mat& original_map, cv::Mat& inflated_map, const int robot_radius_pixel);
+
+	/**
+	 * This function checks a vector of map positions for their accessibility.
+	 *
+	 * \param points_to_check All the map positions whose accessibility shall be tested, in map coordinates [px]
+	 * \param accessibility_flags Response to each map position whether it is accessible (true) or not (false)
+	 * \param inflated_map The map that is to be tested with walls and obstacles inflated by the robot radius
+	 * \param approach_path_accessibility_check If true, there must be a path from robot_location to a goal position in order to report accessibility
+	 * \param robot_location [Optional] The current robot position in the map if approach_path_accessibility_check=true, in map coordinates [px]
+	 */
+	void checkPoses(const std::vector<cv::Point>& points_to_check, std::vector<bool>& accessibility_flags,
+			const cv::Mat& inflated_map, const bool approach_path_accessibility_check, const cv::Point& robot_location);
+
+	/**
+	 * This function checks the accessibility of points on a perimeter around a center point.
+	 *
+	 * \param accessible_poses_on_radius The returned set of accessible poses on the perimeter of the given circle, in map coordinates [px,px,rad]
+	 * \param center Center of the circle whose perimeter should be checked for accessibility, in map coordinates [px,px,rad]
+	 * \param radius Radius of the circle whose perimeter should be checked for accessibility, in [px]
+	 * \param rotational_sampling_step Rotational sampling step width for checking points on the perimeter, in [rad]
+	 * \param inflated_map The map that is to be tested with walls and obstacles inflated by the robot radius
+	 * \param approach_path_accessibility_check If true, there must be a path from robot_location to a goal position in order to report accessibility
+	 * \param robot_location [Optional] The current robot position in the map if approach_path_accessibility_check=true, in map coordinates [px]
+	 */
+	void checkPerimeter(std::vector<Pose>& accessible_poses_on_perimeter,
+			const Pose& center, const double radius, const double rotational_sampling_step,
+			const cv::Mat& inflated_map, const bool approach_path_accessibility_check, const cv::Point& robot_location);
+protected:
+
+	/*
+	 * This function computes whether a given point (potentialApproachPose) is accessible by the robot at location robotLocation
+	 */
+	bool isApproachPositionAccessible(const cv::Point& robotLocation,
+			const cv::Point& potentialApproachPose,
+			std::vector<std::vector<cv::Point> > contours);
+
+	/*
+	 * pose_p and closest_point_on_polygon in pixel coordinates!
+	 */
+	void computeClosestPointOnPolygon(const cv::Mat& map_with_polygon,
+			const Pose& pose_p, Pose& closest_point_on_polygon);
+
+	template<class T>
+	T convertFromMeterToPixelCoordinates(const Pose& pose, const cv::Point2d& map_origin, const double inverse_map_resolution)
+	{
+		T val;
+		val.x = (pose.x - map_origin.x) * inverse_map_resolution;
+		val.y = (pose.y - map_origin.y) * inverse_map_resolution;
+		return val;
+	}
+
+	template<class T>
+	T convertFromPixelCoordinatesToMeter(const Pose& pose, const cv::Point2d& map_origin, const double map_resolution)
+	{
+		T val;
+		val.x = map_resolution * pose.x + map_origin.x;
+		val.y = map_resolution * pose.y + map_origin.y;
+		return val;
+	}
+};
+

--- a/cob_map_accessibility_analysis/ros/include/cob_map_accessibility_analysis/map_accessibility_analysis_server.h
+++ b/cob_map_accessibility_analysis/ros/include/cob_map_accessibility_analysis/map_accessibility_analysis_server.h
@@ -147,7 +147,7 @@ protected:
   // map properties
   double map_resolution_;          // in [m/cell]
   double inverse_map_resolution_;  // in [cell/m]
-  cv::Point2d map_origin_;         // in [m]
+  cv::Point2d map_origin_;         // in [m,m,rad]
   std::string map_link_name_;
 
   // robot

--- a/cob_map_accessibility_analysis/ros/include/cob_map_accessibility_analysis/map_accessibility_analysis_server.h
+++ b/cob_map_accessibility_analysis/ros/include/cob_map_accessibility_analysis/map_accessibility_analysis_server.h
@@ -19,6 +19,7 @@
 #define MAP_ACCESSIBILITY_ANALYSIS_H
 
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 #include <math.h>
@@ -45,8 +46,7 @@
 #include <cob_3d_mapping_msgs/GetApproachPoseForPolygon.h>
 
 // opencv
-#include <opencv/cv.h>
-#include <opencv/highgui.h>
+#include <opencv2/opencv.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.h>
 
@@ -59,35 +59,18 @@
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 
-class MapAccessibilityAnalysis
+#include <cob_map_accessibility_analysis/map_accessibility_analysis.h>
+
+class MapAccessibilityAnalysisServer : public MapAccessibilityAnalysis
 {
 public:
-  MapAccessibilityAnalysis(ros::NodeHandle nh);
-  ~MapAccessibilityAnalysis();
+  MapAccessibilityAnalysisServer(ros::NodeHandle nh);
+  ~MapAccessibilityAnalysisServer();
 
 protected:
-  struct Pose
-  {
-    float x;
-    float y;
-    float orientation;  // in degree
-
-    Pose()
-    {
-      x = 0;
-      y = 0;
-      orientation = 0;
-    }
-
-    Pose(float x_, float y_, float orientation_)
-    {
-      x = x_;
-      y = y_;
-      orientation = orientation_;
-    }
-  };
 
   // reads out the robot footprint from a string or array
+  // returns the polygonal footprint of the robot in [m]
   std::vector<geometry_msgs::Point> loadRobotFootprint(XmlRpc::XmlRpcValue& footprint_list);
 
   // original map initializer
@@ -123,23 +106,6 @@ protected:
 
   // reads the robot coordinates from tf
   cv::Point getRobotLocationInPixelCoordinates();
-
-  // this function computes whether a given point (potentialApproachPose) is accessible by the robot at location
-  // robotLocation
-  bool isApproachPositionAccessible(const cv::Point& robotLocation,
-                                    const cv::Point& potentialApproachPose,
-                                    std::vector<std::vector<cv::Point> > contours);
-
-  // pose_p and closest_point_on_polygon in pixel coordinates!
-  void computeClosestPointOnPolygon(const cv::Mat& map_with_polygon,
-                                    const Pose& pose_p,
-                                    Pose& closest_point_on_polygon);
-
-  template <class T>
-  T convertFromMeterToPixelCoordinates(const Pose& pose);
-
-  template <class T>
-  T convertFromPixelCoordinatesToMeter(const Pose& pose);
 
   ros::NodeHandle node_handle_;
 
@@ -185,7 +151,6 @@ protected:
   std::string map_link_name_;
 
   // robot
-  std::vector<geometry_msgs::Point> footprint_;  // polygonal footprint of the robot in [m]
   double robot_radius_;                          // in [m]
   std::string robot_base_link_name_;
   bool approach_path_accessibility_check_;  // if true, the path to a goal position must be accessible as well

--- a/cob_map_accessibility_analysis/ros/launch/map_accessibility_analysis_params.yaml
+++ b/cob_map_accessibility_analysis/ros/launch/map_accessibility_analysis_params.yaml
@@ -1,4 +1,5 @@
 # if true, the path to a goal position must be accessible as well
+# (this setting is overwritten temporarily on receiving the CheckPointAccessibility.srv message)
 # bool
 approach_path_accessibility_check: false
 

--- a/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis.cpp
+++ b/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis.cpp
@@ -18,7 +18,7 @@
 #include <cob_map_accessibility_analysis/map_accessibility_analysis.h>
 #include <ros/ros.h>
 
-#define __DEBUG_DISPLAYS__
+//#define __DEBUG_DISPLAYS__
 
 MapAccessibilityAnalysis::MapAccessibilityAnalysis()
 {

--- a/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis.cpp
+++ b/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis.cpp
@@ -1,0 +1,181 @@
+/*
+* Copyright (c) 2016-2017 Fraunhofer Institute for Manufacturing Engineering and Automation (IPA)
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <cob_map_accessibility_analysis/map_accessibility_analysis.h>
+#include <ros/ros.h>
+
+//#define __DEBUG_DISPLAYS__
+
+MapAccessibilityAnalysis::MapAccessibilityAnalysis()
+{
+
+}
+
+MapAccessibilityAnalysis::~MapAccessibilityAnalysis()
+{
+
+}
+
+void MapAccessibilityAnalysis::inflateMap(const cv::Mat& original_map, cv::Mat& inflated_map, const int robot_radius_pixel)
+{
+	cv::erode(original_map, inflated_map, cv::Mat(), cv::Point(-1, -1), robot_radius_pixel);
+}
+
+void MapAccessibilityAnalysis::checkPoses(const std::vector<cv::Point>& points_to_check, std::vector<bool>& accessibility_flags,
+		const cv::Mat& inflated_map, const bool approach_path_accessibility_check, const cv::Point& robot_location)
+{
+#ifdef __DEBUG_DISPLAYS__
+	cv::Mat display_map = inflated_map.clone();
+#endif
+
+	// find the individual connected areas
+	std::vector<std::vector<cv::Point> > area_contours; // first index=contour index;  second index=point index within contour
+	if (approach_path_accessibility_check == true)
+	{
+		cv::Mat inflated_map_copy = inflated_map.clone();
+		cv::findContours(inflated_map_copy, area_contours, CV_RETR_LIST, CV_CHAIN_APPROX_SIMPLE);
+	}
+
+	for (unsigned int i = 0; i < points_to_check.size(); ++i)
+	{
+		const int u = points_to_check[i].x;
+		const int v = points_to_check[i].y;
+		ROS_INFO_STREAM("Checking accessibility of point (" << u << ", " << v << ")px.");
+		if (inflated_map.at<uchar>(v, u) != 0)
+		{
+			// check if robot can approach this position
+			if (approach_path_accessibility_check == false ||
+					isApproachPositionAccessible(robot_location, cv::Point(u, v), area_contours) == true)
+				accessibility_flags[i] = true;
+		}
+
+#ifdef __DEBUG_DISPLAYS__
+		if (accessibility_flags[i] == false)
+			cv::circle(display_map, cv::Point(u, v), 2, cv::Scalar(64), 10);
+		else
+			cv::circle(display_map, cv::Point(u, v), 2, cv::Scalar(192), 10);
+#endif
+	}
+
+#ifdef __DEBUG_DISPLAYS__
+	cv::imshow("points", display_map);
+	cv::waitKey();
+#endif
+}
+
+
+void MapAccessibilityAnalysis::checkPerimeter(std::vector<Pose>& accessible_poses_on_perimeter,
+		const Pose& center, const double radius, const double rotational_sampling_step,
+		const cv::Mat& inflated_map, const bool approach_path_accessibility_check, const cv::Point& robot_location)
+{
+#ifdef __DEBUG_DISPLAYS__
+	cv::Mat display_map = inflated_map.clone();
+#endif
+
+	// find the individual connected areas
+	std::vector<std::vector<cv::Point> > area_contours; // first index=contour index;  second index=point index within contour
+	if (approach_path_accessibility_check == true)
+	{
+		cv::Mat inflated_map_copy = inflated_map.clone();
+		cv::findContours(inflated_map_copy, area_contours, CV_RETR_LIST, CV_CHAIN_APPROX_SIMPLE);
+	}
+
+	for (double angle = center.orientation; angle < center.orientation + 2 * CV_PI; angle += rotational_sampling_step)
+	{
+		const double x = center.x + radius * cos(angle);
+		const double y = center.y + radius * sin(angle);
+		const int u = cvRound(x);
+		const int v = cvRound(y);
+		if (inflated_map.at<uchar>(v, u) != 0)
+		{
+			// check if robot can approach this position
+			if (approach_path_accessibility_check == false
+					|| isApproachPositionAccessible(robot_location, cv::Point(u, v), area_contours) == true)
+			{
+				// add accessible point to results
+				Pose pose;
+				pose.x = x;
+				pose.y = y;
+				pose.orientation = angle + CV_PI;
+				while (pose.orientation > 2 * CV_PI)
+					pose.orientation -= 2 * CV_PI;
+				while (pose.orientation < 0.)
+					pose.orientation += 2 * CV_PI;
+				accessible_poses_on_perimeter.push_back(pose);
+
+#ifdef __DEBUG_DISPLAYS__
+				cv::circle(display_map, cv::Point(u, v), 2, cv::Scalar(192), 5);
+#endif
+			}
+		}
+		else
+		{
+#ifdef __DEBUG_DISPLAYS__
+			cv::circle(display_map, cv::Point(u, v), 2, cv::Scalar(64), 5);
+#endif
+		}
+	}
+
+#ifdef __DEBUG_DISPLAYS__
+	cv::imshow("perimeter", display_map);
+	cv::waitKey();
+#endif
+}
+
+
+bool MapAccessibilityAnalysis::isApproachPositionAccessible(const cv::Point& robotLocation,
+		const cv::Point& potentialApproachPose, std::vector<std::vector<cv::Point> > contours)
+{
+	// check whether potentialApproachPose and robotLocation are in the same area (=same contour)
+	int contourIndexRobot = -1;
+	int contourIndexPotentialApproachPose = -1;
+	for (unsigned int i = 0; i < contours.size(); i++)
+	{
+		if (0 <= cv::pointPolygonTest(contours[i], potentialApproachPose, false))
+			contourIndexPotentialApproachPose = i;
+		if (0 <= cv::pointPolygonTest(contours[i], robotLocation, false))
+			contourIndexRobot = i;
+	}
+	ROS_DEBUG_STREAM("contourIndexPotentialApproachPose=" << contourIndexPotentialApproachPose
+					<< "  contourIndexRobot=" << contourIndexRobot);
+	if (contourIndexRobot != contourIndexPotentialApproachPose ||
+			(contourIndexRobot == -1 && contourIndexPotentialApproachPose == -1))
+		return false;
+
+	return true;
+}
+
+
+void MapAccessibilityAnalysis::computeClosestPointOnPolygon(const cv::Mat& map_with_polygon,
+		const Pose& pose_p, Pose& closest_point_on_polygon)
+{
+	double closest_pixel_distance_squared = 1e10;
+	for (int v = 0; v < map_with_polygon.rows; v++)
+	{
+		for (int u = 0; u < map_with_polygon.cols; u++)
+		{
+			double dist_squared = 0.;
+			if (map_with_polygon.at<uchar>(v, u) == 128 &&
+				(dist_squared = (pose_p.x - u) * (pose_p.x - u) + (pose_p.y - v) * (pose_p.y - v)) < closest_pixel_distance_squared)
+			{
+				closest_pixel_distance_squared = dist_squared;
+				closest_point_on_polygon.x = u;
+				closest_point_on_polygon.y = v;
+			}
+		}
+	}
+}

--- a/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis.cpp
+++ b/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis.cpp
@@ -18,7 +18,7 @@
 #include <cob_map_accessibility_analysis/map_accessibility_analysis.h>
 #include <ros/ros.h>
 
-//#define __DEBUG_DISPLAYS__
+#define __DEBUG_DISPLAYS__
 
 MapAccessibilityAnalysis::MapAccessibilityAnalysis()
 {
@@ -65,7 +65,7 @@ void MapAccessibilityAnalysis::checkPoses(const std::vector<cv::Point>& points_t
 
 #ifdef __DEBUG_DISPLAYS__
 		if (accessibility_flags[i] == false)
-			cv::circle(display_map, cv::Point(u, v), 2, cv::Scalar(64), 10);
+			cv::circle(display_map, cv::Point(u, v), 2, cv::Scalar(32), 10);
 		else
 			cv::circle(display_map, cv::Point(u, v), 2, cv::Scalar(192), 10);
 #endif
@@ -100,6 +100,7 @@ void MapAccessibilityAnalysis::checkPerimeter(std::vector<Pose>& accessible_pose
 		const double y = center.y + radius * sin(angle);
 		const int u = cvRound(x);
 		const int v = cvRound(y);
+		bool found_pose = false;
 		if (inflated_map.at<uchar>(v, u) != 0)
 		{
 			// check if robot can approach this position
@@ -116,18 +117,15 @@ void MapAccessibilityAnalysis::checkPerimeter(std::vector<Pose>& accessible_pose
 				while (pose.orientation < 0.)
 					pose.orientation += 2 * CV_PI;
 				accessible_poses_on_perimeter.push_back(pose);
-
-#ifdef __DEBUG_DISPLAYS__
-				cv::circle(display_map, cv::Point(u, v), 2, cv::Scalar(192), 5);
-#endif
+				found_pose = true;
 			}
 		}
-		else
-		{
 #ifdef __DEBUG_DISPLAYS__
-			cv::circle(display_map, cv::Point(u, v), 2, cv::Scalar(64), 5);
+		if (found_pose == true)
+			cv::circle(display_map, cv::Point(u, v), 2, cv::Scalar(192), 5);
+		else
+			cv::circle(display_map, cv::Point(u, v), 2, cv::Scalar(32), 5);
 #endif
-		}
 	}
 
 #ifdef __DEBUG_DISPLAYS__

--- a/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis_client.cpp
+++ b/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis_client.cpp
@@ -85,9 +85,9 @@ int main(int argc, char** argv)
   cob_map_accessibility_analysis::CheckPerimeterAccessibility::Response res_perimeter;
 
   req_perimeter.center.x = 2.5;
-  req_perimeter.center.y = 2.25;
+  req_perimeter.center.y = 0.5;
   req_perimeter.center.theta = 0.;
-  req_perimeter.radius = 0.45;
+  req_perimeter.radius = 1.0;
   req_perimeter.rotational_sampling_step = 10. / 180. * M_PI;
 
   // this calls the service server to process our request message and put the result into the response message

--- a/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis_server.cpp
+++ b/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis_server.cpp
@@ -18,7 +18,7 @@
 #include <cob_map_accessibility_analysis/map_accessibility_analysis_server.h>
 #include <pcl_ros/point_cloud.h>
 
-#define __DEBUG_DISPLAYS__
+//#define __DEBUG_DISPLAYS__
 
 MapAccessibilityAnalysisServer::MapAccessibilityAnalysisServer(ros::NodeHandle nh) : node_handle_(nh)
 {

--- a/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis_server.cpp
+++ b/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis_server.cpp
@@ -447,8 +447,7 @@ bool MapAccessibilityAnalysisServer::checkPolygonCallback(cob_3d_mapping_msgs::G
       std::vector<cv::Point> p_vec(pc.size());
       for (unsigned int j = 0; j < pc.size(); j++)
       {
-        p_vec[j] = convertFromMeterToPixelCoordinates<cv::Point>(Pose(pc.points[j].x, pc.points[j].y, 0),
-                                                                 map_origin_, inverse_map_resolution_);
+        p_vec[j] = convertFromMeterToPixelCoordinates<cv::Point>(Pose(pc.points[j].x, pc.points[j].y, 0), map_origin_, inverse_map_resolution_);
       }
       polygon_contours.push_back(p_vec);
     }
@@ -457,8 +456,7 @@ bool MapAccessibilityAnalysisServer::checkPolygonCallback(cob_3d_mapping_msgs::G
   // compute inflated polygon
   cv::Mat polygon_expanded = 255 * cv::Mat::ones(original_map_.rows, original_map_.cols, original_map_.type());
   cv::drawContours(polygon_expanded, polygon_contours, -1, cv::Scalar(128), CV_FILLED);
-  int iterations = cvRound(robot_radius_ * inverse_map_resolution_);
-  cv::erode(polygon_expanded, polygon_expanded, cv::Mat(), cv::Point(-1, -1), iterations);
+  cv::erode(polygon_expanded, polygon_expanded, cv::Mat(), cv::Point(-1, -1), cvRound(robot_radius_ * inverse_map_resolution_));
 
   // combine inflated polygon with inflated map
   cv::Mat inflated_map;
@@ -472,8 +470,7 @@ bool MapAccessibilityAnalysisServer::checkPolygonCallback(cob_3d_mapping_msgs::G
 #endif
 
   // find the individual connected areas
-  std::vector<std::vector<cv::Point> > area_contours;  // first index=contour index;  second index=point index within
-                                                       // contour
+  std::vector<std::vector<cv::Point> > area_contours;  // first index=contour index;  second index=point index within contour
   if (approach_path_accessibility_check_ == true)
   {
     cv::Mat inflated_map_copy = inflated_map.clone();

--- a/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis_server.cpp
+++ b/cob_map_accessibility_analysis/ros/src/map_accessibility_analysis_server.cpp
@@ -18,7 +18,7 @@
 #include <cob_map_accessibility_analysis/map_accessibility_analysis_server.h>
 #include <pcl_ros/point_cloud.h>
 
-//#define __DEBUG_DISPLAYS__
+#define __DEBUG_DISPLAYS__
 
 MapAccessibilityAnalysisServer::MapAccessibilityAnalysisServer(ros::NodeHandle nh) : node_handle_(nh)
 {
@@ -409,7 +409,7 @@ bool MapAccessibilityAnalysisServer::checkPerimeterCallback(
   // compute accessibility
   {
     boost::mutex::scoped_lock lock(mutex_inflated_map_);
-    checkPerimeter(accessible_poses_on_perimeter, center, req.radius, req.rotational_sampling_step, inflated_map_,
+    checkPerimeter(accessible_poses_on_perimeter, center, req.radius*inverse_map_resolution_, req.rotational_sampling_step, inflated_map_,
                    approach_path_accessibility_check_, robot_location);
   }
 


### PR DESCRIPTION
Just a separation of the core functionality from the ROS service message interface. Map accessibility can now be checked for a set of points or a circle by including a C++ library (new) or by calling the ROS service (the old way).

Function and interface should still be 100% the same, just that the functions are moved to a separate file and can be used as lib as well.

Can someone ( @ipa-bnm , @ipa-fmw, @ipa-fxm ) please confirm that the software is still doing its job if it is used for MSH?