### PR TITLE
fixed goal Validation

### DIFF
--- a/cob_linear_nav/src/cob_linear_nav.cpp
+++ b/cob_linear_nav/src/cob_linear_nav.cpp
@@ -495,13 +495,13 @@ bool NodeClass::goalValid(const geometry_msgs::PoseStamped& goal_pose)
     ROS_WARN("Goal invalid! Received Quaternion with all values 0.0!");
     return false;
   }
-  else if (!tf_listener_.canTransform(global_frame_, goal_pose.header.frame_id, goal_pose.header.stamp, new std::string))
+  else if (!tf_listener_.waitForTransform(global_frame_, goal_pose.header.frame_id, goal_pose.header.stamp, ros::Duration(1.0)))
   {
     ROS_WARN_STREAM("Can not transform goal which is given in /"
                     << goal_pose.header.frame_id << " into global frame /" << global_frame_);
     return false;
   }
-  else if (!tf_listener_.canTransform(robot_frame_, goal_pose.header.frame_id, goal_pose.header.stamp, new std::string))
+  else if (!tf_listener_.waitForTransform(robot_frame_, goal_pose.header.frame_id, goal_pose.header.stamp, ros::Duration(1.0)))
   {
      ROS_WARN_STREAM("Can not transform goal which is given in /"
                       << goal_pose.header.frame_id << " into robot frame /" << robot_frame_);


### PR DESCRIPTION
replaced canTransform with waitForTransform to give move_base some chance receiving the transformation needed for the requested move base goal. e.g. if we use the 2DNavGoal Tool from rviz the goal timestamp is filled with the current time, but move_base has not received transformation yet.

