### PR TITLE
speed-up roslaunch checks

### DIFF
--- a/cob_navigation_global/CMakeLists.txt
+++ b/cob_navigation_global/CMakeLists.txt
@@ -21,10 +21,11 @@ if(CATKIN_ENABLE_TESTING)
   find_package(cob_supported_robots REQUIRED)
   find_package(roslaunch REQUIRED)
   foreach(robot ${cob_supported_robots_ROBOTLIST})
-    foreach(env ${cob_default_env_config_ENVLIST})
+    #foreach(env ${cob_default_env_config_ENVLIST}) # no need to loop over envs as env-specific map.yaml (filepath) is only used as arg string for map server and not as file
+      set(env "empty")
       message("testing for robot: ${robot} in env: ${env}")
       roslaunch_add_file_check(launch ROBOT=${robot} ROBOT_ENV=${env})   # testing environment variables
       roslaunch_add_file_check(launch robot:=${robot} robot_env:=${env}) # testing launch file arguments
-    endforeach()
+    #endforeach()
   endforeach()
 endif()


### PR DESCRIPTION
the env-specific file `map.yaml` cannot be detected (if missing) by the roslaunch check as only the file name string is used as node arg - rather than using the file....thus, we do not need to check the envs but just one....

I will add a check about mandatory files in `cob_default_env_config` directly